### PR TITLE
CartridgeMenu: fix cartstart entry in extended menu

### DIFF
--- a/com.wudsn.productions.atari800.thecartstudio/src/com/wudsn/tools/thecartstudio/model/CartridgeMenu.java
+++ b/com.wudsn.productions.atari800.thecartstudio/src/com/wudsn/tools/thecartstudio/model/CartridgeMenu.java
@@ -419,7 +419,7 @@ public final class CartridgeMenu {
 
 					// Adapt default menu start vector (2 bytes) from cartridge
 					// initialization to jump table..
-					System.arraycopy(extendedMenuContent, Offsets.CARTCS, simpleMenuContent,
+					System.arraycopy(extendedMenuContent, Offsets.CARTCS, extendedMenuContent,
 							Offsets.ENTRY_DEFAULT_CARTSTART + 1, 2);
 
 					// Copy second part (flasher and PicoDos)


### PR DESCRIPTION
The start entry needs to be changed in the extended menu, not the simple menu.