### PR TITLE
thecart-menu: fix compatibility with SECAM FGTIAs

### DIFF
--- a/com.wudsn.productions.atari800.thecartstudio/asm/thecart-menu/TheMenu-Starter.asm
+++ b/com.wudsn.productions.atari800.thecartstudio/asm/thecart-menu/TheMenu-Starter.asm
@@ -30,6 +30,8 @@
 	lda #the_cart_mode.tc_mode_off	;Disable and lock the cartridge
 	sta the_cart.mode
 	sta the_cart.configuration_lock
+	sta wsync
+	sta wsync
 	mva trig3 gintlk		;Make sure cartridge status is up to date
 	cli
 	jmp coldsv
@@ -40,6 +42,8 @@
 	ldx #<0
 	ldy #>0
 	jsr menu_core.set_bank
+	sta wsync
+	sta wsync
 	mva trig3 gintlk
 	cli				;Enabled VBI stage 2
 	rts

--- a/com.wudsn.productions.atari800.thecartstudio/asm/thecart-menu/TheMenu.asm
+++ b/com.wudsn.productions.atari800.thecartstudio/asm/thecart-menu/TheMenu.asm
@@ -145,6 +145,8 @@ skip_signature
 
 	sei			;Prevent VBI stage 2 before disabling The!Cart
 	mva #0 the_cart.primary_bank_enable
+	sta wsync
+	sta wsync
 	mva trig3 gintlk	;Make sure cartridge status is up to date
 	cli			;Enable VBI state 2 again
 


### PR DESCRIPTION
FGTIAs latch trigger inputs at the beginning of HBLANK, add two STA WSYNCs before reading TRIG3 to ensure it reflects the actual RD5 status.

Note: ATR and XEX loader likely need a similar fix before leaving the critical section, this is not addressed by these changes yet.

see https://abbuc.de/forum/viewtopic.php?f=3&t=5130